### PR TITLE
feat: add AssetCard component

### DIFF
--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -1,0 +1,46 @@
+import { BLANK, formatCurrencyFromCents } from "@/lib/format";
+
+type Props = {
+  name: string;
+  address?: string;
+  city?: string;
+  state?: string;
+  status?: string;
+  photoUrl?: string;
+  unitCount?: number;
+  avgRentCents?: number;
+  onOpen?: () => void;
+};
+
+export default function AssetCard(p: Props) {
+  return (
+    <div className="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4 grid grid-cols-[96px,1fr,auto] gap-4">
+      <img
+        src={p.photoUrl ?? "/placeholder-asset.jpg"}
+        alt={p.name}
+        className="h-24 w-24 rounded-xl object-cover bg-zinc-800"
+      />
+      <div className="min-w-0">
+        <div className="font-semibold truncate">{p.name}</div>
+        <div className="text-sm text-zinc-400 truncate">
+          {p.address ?? BLANK}{p.city ? `, ${p.city}` : ""}{p.state ? `, ${p.state}` : ""}
+        </div>
+        <div className="mt-2 flex gap-3 text-sm">
+          <span className="rounded-md bg-zinc-800/60 px-2 py-0.5">{p.status ?? "Unknown"}</span>
+          <span className="rounded-md bg-zinc-800/60 px-2 py-0.5">{p.unitCount ?? 0} units</span>
+          <span className="rounded-md bg-zinc-800/60 px-2 py-0.5">
+            {p.avgRentCents != null ? formatCurrencyFromCents(p.avgRentCents) : BLANK} avg rent
+          </span>
+        </div>
+      </div>
+      <div className="flex items-start">
+        <button
+          onClick={p.onOpen}
+          className="rounded-xl border border-zinc-700 px-3 py-2 hover:bg-zinc-800"
+        >
+          Open
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# Pull Request Title

<!-- Concise description of what this PR does -->

---

## 📑 Overview
- [ ] Related Issue(s): Closes #ISSUE_NUMBER
- [ ] Milestone: Genesis Phase 1 (Frontend)
- [ ] Labels: [ ] frontend [ ] dashboard [ ] portfolio [ ] asset-cards [ ] legal [ ] owners [ ] infra

---

## 🛠️ Changes
<!-- List of changes grouped logically -->

- [ ] Dashboard Fix
- [ ] Portfolio Tables
- [ ] Asset Cards
- [ ] Legal Page
- [ ] Owner Transfer Page
- [ ] Global Guardrails/Infra

---

## 🔒 Guardrails Check
- [ ] Router: **wouter only** (no react-router-dom)
- [ ] No hardcoded KPIs (data from Supabase/Azure APIs only)
- [ ] All components styled with `.ecc-object` surface
- [ ] Theme = Altus black/gold (✅ no orange)
- [ ] Navigation added only in `src/config/navigation.ts`
- [ ] Atomic components used where applicable (FieldRows, KPI, ActionButton, MiniCard, ActivityChip)
- [ ] BFF endpoints used for admin operations (`/api/bff/*`)

---

## ✅ Verification Checklist
- [ ] Build compiles with no errors
- [ ] Dashboard KPIs = Properties 181, Units 176 (match Supabase)
- [ ] Tables use MUI DataGrid, export works
- [ ] Asset Cards load with skeleton loaders + lazy tabs
- [ ] Legal page loads, filters + activity feed working
- [ ] Owner Transfer flow: Approval → Authorize → Execute, logs + accounting packet
- [ ] Playwright/audit scripts run successfully
- [ ] No raw hex codes in CSS (tokens only)
- [ ] Git branch clean, commits descriptive

---

## 📸 Screenshots / Logs
<!-- Paste screenshots, curl outputs, or logs here for QA proof -->

---

## 🔗 Dependencies
- [ ] Dashboard completed before Portfolio/Asset Cards
- [ ] Owner Transfer after BFF + audit infra
- [ ] Global Guardrails always pass

---

## 🚀 Deployment Notes
- [ ] Secrets present in GitHub/Env (DOORLOOP_API_KEY, M365_*, DROPBOX_KEY)
- [ ] No `.env` values committed
- [ ] Feature flags validated via `/api/config/integrations`

---

## 📝 Reviewer Notes
- [ ] Confirm UI matches Genesis design
- [ ] Confirm counts match backend truth
- [ ] Confirm no drift from repo structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an Asset Card UI to display property details at a glance.
  * Shows image with a placeholder fallback, property name, and a neatly formatted address.
  * Displays status, unit count, and average rent as compact pills with sensible defaults.
  * Supports currency formatting for rent and graceful handling of missing data.
  * Includes an “Open” button to trigger an action for the selected asset.
  * Responsive, grid-based layout with text truncation for long values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->