### PR TITLE
Add ECC frontend autonomy scaffold

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-task.md
+++ b/.github/ISSUE_TEMPLATE/agent-task.md
@@ -1,0 +1,19 @@
+---
+name: Agent Task
+about: Structured intake for Codex-scoped work in Replit_Front_End_ECC
+labels: agent-task
+---
+
+## Objective
+
+## Constraints
+-
+
+## Files / Systems In Scope
+-
+
+## Acceptance Checks
+- [ ]
+
+## Do-Not-Touch List
+-

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,21 +1,20 @@
 ---
-name: Bug Report
-about: Something broke or behaves incorrectly
+name: Bug
+about: Report a defect or regression in Replit_Front_End_ECC
 labels: bug, frontend
 ---
 
-### What happened
-<!-- describe -->
+## Summary
 
-### Steps to reproduce
+## Expected Behavior
+
+## Actual Behavior
+
+## Reproduction Steps
 1.
 2.
+3.
 
-### Expected
-<!-- describe -->
+## Scope / Impact
 
-### Screenshots/Logs
-<!-- optional -->
-
-### Impact
-<!-- user/system impact -->
+## Evidence

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,18 +1,20 @@
 ---
-name: Feature Request
-about: Propose a new capability or page
+name: Feature
+about: Request a new Replit_Front_End_ECC capability or enhancement
 labels: enhancement, frontend
 ---
 
-### Problem / Opportunity
-<!-- Why this matters -->
+## Summary
 
-### Proposal
-<!-- What should be built -->
+## Problem To Solve
 
-### Acceptance Criteria
-- [ ] 
-- [ ] 
+## Proposed Outcome
 
-### Additional context
-<!-- links, mockups -->
+## Scope Boundaries
+- In scope:
+  -
+- Out of scope:
+  -
+
+## Acceptance Criteria
+- [ ]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,30 @@
-Acceptance Authority: This PR is submitted under the Proof Authority Ladder. Tier [X] evidence applies. No additional runner-generated artifacts are required unless explicitly requested by CD.
+## Summary
+-
+
+## Scope Boundaries
+- In scope:
+  -
+- Out of scope:
+  -
+
+## Validation Run
+- [ ] File review completed
+- [ ] Local validation run (describe below)
+- [ ] No validation run needed (explain why)
+
+Validation details:
+
+## Secrets / Env Impact
+- [ ] No secrets or environment changes
+- [ ] Secrets or env references changed (describe below)
+
+Details:
+
+## Workflow / Runtime Impact
+- [ ] No workflow or runtime impact
+- [ ] Workflow or runtime impact exists (describe below)
+
+Details:
+
+## Rollback Note
+- Revert this PR to restore the previous scaffold state.

--- a/.github/workflows/codex-ready-check.yml
+++ b/.github/workflows/codex-ready-check.yml
@@ -1,0 +1,81 @@
+name: Codex Ready Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      objective:
+        description: 'Short objective for the task'
+        required: true
+        type: string
+      constraints:
+        description: 'Key constraints or guardrails'
+        required: true
+        type: string
+      scope:
+        description: 'Files or systems in scope'
+        required: true
+        type: string
+      acceptance_checks:
+        description: 'Acceptance checks to confirm readiness'
+        required: true
+        type: string
+      do_not_touch:
+        description: 'Explicit do-not-touch list'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  normalize-task:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate required metadata
+        shell: bash
+        env:
+          OBJECTIVE: ${{ inputs.objective }}
+          CONSTRAINTS: ${{ inputs.constraints }}
+          SCOPE: ${{ inputs.scope }}
+          ACCEPTANCE_CHECKS: ${{ inputs.acceptance_checks }}
+          DO_NOT_TOUCH: ${{ inputs.do_not_touch }}
+        run: |
+          set -euo pipefail
+
+          for name in OBJECTIVE CONSTRAINTS SCOPE ACCEPTANCE_CHECKS DO_NOT_TOUCH; do
+            value="${!name}"
+            if [ -z "${value// }" ]; then
+              echo "::error::${name} is required."
+              exit 1
+            fi
+          done
+
+      - name: Emit normalized ready summary
+        shell: bash
+        run: |
+          {
+            echo "## Ready for Codex"
+            echo ""
+            echo "- Repository: ${GITHUB_REPOSITORY}"
+            echo "- Ref: ${GITHUB_REF_NAME}"
+            echo "- Actor: ${GITHUB_ACTOR}"
+            echo "- Objective: ${{ inputs.objective }}"
+            echo "- Constraints: ${{ inputs.constraints }}"
+            echo "- Scope: ${{ inputs.scope }}"
+            echo "- Acceptance checks: ${{ inputs.acceptance_checks }}"
+            echo "- Do not touch: ${{ inputs.do_not_touch }}"
+            echo "- Safety: manual-only, read-safe, no cross-repo mutation"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Echo machine-readable payload
+        shell: bash
+        run: |
+          printf '%s\n' \
+            "ready_for_codex=true" \
+            "repository=${GITHUB_REPOSITORY}" \
+            "ref=${GITHUB_REF_NAME}" \
+            "objective=${{ inputs.objective }}" \
+            "constraints=${{ inputs.constraints }}" \
+            "scope=${{ inputs.scope }}" \
+            "acceptance_checks=${{ inputs.acceptance_checks }}" \
+            "do_not_touch=${{ inputs.do_not_touch }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+## Purpose
+`Replit_Front_End_ECC` is the ECC frontend ownership layer for Altus. It contains the ECC user interface, local adapter and proxy surfaces, and frontend integration patterns used to consume backend contracts without redefining them.
+
+## What Codex May Change
+- Repo-local documentation, templates, and workflow metadata
+- Non-destructive scaffolding that improves task intake, review, and handoff
+- Low-risk developer workflow files that are manual-only and read-safe
+- Frontend product code only when a task explicitly requests frontend changes
+
+## What Codex Must Not Touch
+- Deploy workflows, Azure configuration, runtime ownership, or backend target wiring
+- API proxy targets, backend base URLs, or legacy runtime references unless explicitly instructed
+- Backend business logic additions or backend contract invention
+- Supabase wiring, secrets, or environment mutation
+- Cross-repo automation or any workflow that mutates other repositories
+- Push-triggered or scheduled write workflows
+- Direct secret handling or repo visibility/settings unless explicitly requested
+
+## Branch Naming
+- Use `codex/*` branches for all Codex-authored changes
+- Keep each branch limited to one task or one safe scaffold increment
+
+## Validation Expectations
+- Read the affected files before editing
+- Keep changes ASCII unless the file already requires otherwise
+- Validate workflow YAML for obvious syntax mistakes
+- Prefer repo-local checks relevant to the touched area and summarize what was and was not validated in the PR
+- Preserve adapter-based integration boundaries rather than inventing new direct contracts
+
+## Secrets And Deploy Guardrails
+- Never print, rotate, or rewrite secrets
+- Never add workflows that require production credentials unless explicitly approved
+- Prefer `workflow_dispatch` for new coordination workflows in this repo
+- Do not add scheduled or push-triggered jobs that can change infrastructure, data, or product state
+- Treat frontend-to-backend adapters, API proxy configuration, Supabase env usage, and legacy runtime references as guarded surfaces
+
+## Pull Request Expectations
+- Keep PRs narrow and reversible
+- Describe scope boundaries and any systems intentionally left untouched
+- Call out workflow, runtime, adapter, contract, or env impact explicitly
+- Include rollback notes for any scaffold or workflow change


### PR DESCRIPTION
## Summary
- add a repo-level AGENTS.md tailored to Replit_Front_End_ECC
- add standard PR and issue templates for Codex task intake
- add a manual-only Codex Ready Check workflow

## Scope Boundaries
- In scope:
  - repo-local scaffold files only
- Out of scope:
  - deploy workflow changes
  - Azure target changes
  - API proxy target changes
  - frontend product code
  - Supabase wiring changes
  - scheduled or push-triggered write workflows
  - runtime changes

## Validation Run
- [x] File review completed
- [x] Local validation run (git diff --check)
- [ ] No validation run needed

Validation details:
- reviewed the new scaffold files locally
- confirmed the new workflow is workflow_dispatch only with contents: read permissions

## Secrets / Env Impact
- [x] No secrets or environment changes
- [ ] Secrets or env references changed

Details:
- none

## Workflow / Runtime Impact
- [ ] No workflow or runtime impact
- [x] Workflow or runtime impact exists

Details:
- adds one new manual-only metadata workflow with no write behavior and no cross-repo mutation

## Rollback Note
- revert this PR to remove the scaffold files and restore the previous state.
