### PR TITLE
Install Phase 1 ECC KPI strips and active scope summaries

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -27,10 +27,30 @@ type IconName =
   | "Building2" | "Wrench" | "Cpu" | "Link2" | "ChartNoAxesColumn" | "FileSpreadsheet" | "Shuffle";
 
 type NavChild = { title: string; path: string; icon?: IconName };
-type NavParent = { title: string; icon: IconName; path?: string; children?: NavChild[] };
+type NavParent = { title: string; icon: IconName; path?: string; children?: NavChild[]; disabled?: boolean };
+
+const LIVE_ROUTES = new Set([
+  "/dashboard",
+  "/data",
+  "/portfolio/properties",
+  "/portfolio/units",
+  "/portfolio/leases",
+  "/portfolio/tenants",
+  "/portfolio/owners",
+  "/owners/transfer",
+  "/reports/create",
+  "/reports/saved",
+  "/reports/templates",
+  "/admin/sync",
+  "/admin/geocode",
+  "/admin/transfers",
+  "/systems/integrations",
+  "/owners/transfer/detail",
+]);
 
 const NAV: NavParent[] = [
   { title: "Dashboard", icon: "LayoutDashboard", path: "/dashboard" },
+  { title: "Data Hub", icon: "Database", path: "/data" },
   {
     title: "Portfolio V3", icon: "Boxes",
     children: [
@@ -45,22 +65,27 @@ const NAV: NavParent[] = [
   {
     title: "Accounting", icon: "FileText",
     children: [ { title: "Overview", path: "/ops/accounting/overview", icon: "ClipboardList" } ],
+    disabled: true,
   },
   {
     title: "AI Analytics", icon: "Shield",
     children: [ { title: "Risk Summary", path: "/ops/ai/risk-summary", icon: "Shield" } ],
+    disabled: true,
   },
   {
     title: "Legal Tracker", icon: "Scale",
     children: [ { title: "Case Manager", path: "/ops/legal/case-manager", icon: "ClipboardList" } ],
+    disabled: true,
   },
   {
     title: "Communication", icon: "MessageSquare",
     children: [ { title: "Queue", path: "/ops/comms/queue", icon: "MessageSquare" } ],
+    disabled: true,
   },
   {
     title: "Construction & Repair", icon: "Hammer",
     children: [ { title: "Work Orders", path: "/ops/maintenance/work-orders", icon: "Hammer" } ],
+    disabled: true,
   },
   { 
     title: "Reports", 
@@ -71,25 +96,27 @@ const NAV: NavParent[] = [
       { title: "Templates", path: "/reports/templates", icon: "FileText" },
     ]
   },
-  { title: "Growth", icon: "PieChart", children: [{ title: "Marketing", path: "/growth/marketing", icon: "PieChart" }] },
+  { title: "Growth", icon: "PieChart", children: [{ title: "Marketing", path: "/growth/marketing", icon: "PieChart" }], disabled: true },
   {
     title: "Systems", icon: "Settings",
     children: [ 
-      { title: "Settings", path: "/system/settings", icon: "Settings" },
       { title: "Integrations", path: "/systems/integrations", icon: "Link2" },
     ],
   },
   {
     title: "Data Management", icon: "Database",
     children: [ { title: "Sync Audit", path: "/data/sync-audit", icon: "ClipboardList" } ],
+    disabled: true,
   },
   {
     title: "Investor Portal", icon: "PieChart",
     children: [ { title: "Dashboard", path: "/investor/dashboard", icon: "LayoutDashboard" } ],
+    disabled: true,
   },
   {
     title: "Integrations", icon: "Link2",
     children: [ { title: "Dropbox Files", path: "/integrations/dropbox", icon: "FolderOpen" } ],
+    disabled: true,
   },
 ];
 
@@ -133,11 +160,26 @@ export default function Sidebar() {
   const [location] = useLocation();
   const { collapsed, setCollapsed } = useCollapsed();
   const [expandedTitle, setExpandedTitle] = useState<string | null>(null);
+  const liveNav = useMemo(
+    () =>
+      NAV.map((item) => {
+        const liveChildren = item.children?.filter((child) => LIVE_ROUTES.has(child.path)) ?? [];
+        return {
+          ...item,
+          path: item.path && LIVE_ROUTES.has(item.path) ? item.path : undefined,
+          children: liveChildren,
+          disabled: item.disabled || (!item.path && liveChildren.length === 0),
+        };
+      }),
+    [],
+  );
 
   useEffect(() => {
-    const activeParent = NAV.find(p => p.children?.some(c => location.startsWith(c.path)) || (p.path && location.startsWith(p.path)));
+    const activeParent = liveNav.find(
+      (p) => p.children?.some((c) => location.startsWith(c.path)) || (p.path && location.startsWith(p.path)),
+    );
     setExpandedTitle(activeParent?.title || null);
-  }, [location]);
+  }, [liveNav, location]);
 
   const [flyOpen, setFlyOpen] = useState(false);
   const [flyTitle, setFlyTitle] = useState("");
@@ -213,19 +255,20 @@ export default function Sidebar() {
         </div>
 
         <nav className="ecc-scroll" role="list">
-          {NAV.map((p) => {
+          {liveNav.map((p) => {
             const ParentIcon = iconOf(p.icon);
             const hasKids = !!p.children?.length;
             const isExpanded = expandedTitle === p.title;
             const parentActive = isActive(p.path) || (hasKids && p.children!.some((c) => isActive(c.path)));
             const rowRef = useRef<HTMLDivElement | null>(null);
+            const isDisabled = p.disabled;
 
             const rowContent = (
               <div
                 className="ecc-row-inner"
                 onMouseEnter={() => {
                   hoverParent.current = true;
-                  if (collapsed && hasKids && rowRef.current) scheduleOpen(p, rowRef.current.getBoundingClientRect());
+                  if (collapsed && hasKids && !isDisabled && rowRef.current) scheduleOpen(p, rowRef.current.getBoundingClientRect());
                 }}
                 onMouseLeave={() => {
                   hoverParent.current = false;
@@ -236,6 +279,11 @@ export default function Sidebar() {
                 {!collapsed && (
                   <>
                     <span className="ecc-label">{p.title}</span>
+                    {isDisabled && (
+                      <span className="ml-auto rounded border border-[#8b7340] bg-[#3b3425] px-1.5 py-0.5 text-[8px] uppercase tracking-[0.08em] text-[#f0e2bd]">
+                        Soon
+                      </span>
+                    )}
                     {hasKids && <div className="ecc-caret">{isExpanded ? <Icons.ChevronDown size={16} /> : <Icons.ChevronRight size={16} />}</div>}
                   </>
                 )}
@@ -243,7 +291,7 @@ export default function Sidebar() {
             );
 
             // If it's a direct link with no children, the whole row is a Link.
-            if (p.path && !hasKids) {
+            if (p.path && !hasKids && !isDisabled) {
               return (
                 <div key={p.title} ref={rowRef}>
                   <Link href={p.path} className={`ecc-row ${parentActive ? "is-active" : ""}`}>
@@ -255,15 +303,23 @@ export default function Sidebar() {
 
             // If it has children, it's a div that toggles them.
             return (
-              <div key={p.title} ref={rowRef} className={`ecc-row ${parentActive ? "is-active" : ""}`}>
+              <div
+                key={p.title}
+                ref={rowRef}
+                className={`ecc-row ${parentActive ? "is-active" : ""} ${isDisabled ? "opacity-60" : ""}`}
+                aria-disabled={isDisabled}
+              >
                 <div
                     className="ecc-row-clickable"
-                    onClick={() => setExpandedTitle(isExpanded ? null : p.title)}
+                    onClick={() => {
+                      if (isDisabled || !hasKids) return;
+                      setExpandedTitle(isExpanded ? null : p.title);
+                    }}
                 >
                     {rowContent}
                 </div>
 
-                {!collapsed && hasKids && isExpanded && (
+                {!collapsed && hasKids && isExpanded && !isDisabled && (
                   <div className="ecc-children" role="group">
                     {p.children!.map((c) => {
                       const CIcon = iconOf(c.icon);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -27,30 +27,10 @@ type IconName =
   | "Building2" | "Wrench" | "Cpu" | "Link2" | "ChartNoAxesColumn" | "FileSpreadsheet" | "Shuffle";
 
 type NavChild = { title: string; path: string; icon?: IconName };
-type NavParent = { title: string; icon: IconName; path?: string; children?: NavChild[]; disabled?: boolean };
-
-const LIVE_ROUTES = new Set([
-  "/dashboard",
-  "/data",
-  "/portfolio/properties",
-  "/portfolio/units",
-  "/portfolio/leases",
-  "/portfolio/tenants",
-  "/portfolio/owners",
-  "/owners/transfer",
-  "/reports/create",
-  "/reports/saved",
-  "/reports/templates",
-  "/admin/sync",
-  "/admin/geocode",
-  "/admin/transfers",
-  "/systems/integrations",
-  "/owners/transfer/detail",
-]);
+type NavParent = { title: string; icon: IconName; path?: string; children?: NavChild[] };
 
 const NAV: NavParent[] = [
   { title: "Dashboard", icon: "LayoutDashboard", path: "/dashboard" },
-  { title: "Data Hub", icon: "Database", path: "/data" },
   {
     title: "Portfolio V3", icon: "Boxes",
     children: [
@@ -65,27 +45,22 @@ const NAV: NavParent[] = [
   {
     title: "Accounting", icon: "FileText",
     children: [ { title: "Overview", path: "/ops/accounting/overview", icon: "ClipboardList" } ],
-    disabled: true,
   },
   {
     title: "AI Analytics", icon: "Shield",
     children: [ { title: "Risk Summary", path: "/ops/ai/risk-summary", icon: "Shield" } ],
-    disabled: true,
   },
   {
     title: "Legal Tracker", icon: "Scale",
     children: [ { title: "Case Manager", path: "/ops/legal/case-manager", icon: "ClipboardList" } ],
-    disabled: true,
   },
   {
     title: "Communication", icon: "MessageSquare",
     children: [ { title: "Queue", path: "/ops/comms/queue", icon: "MessageSquare" } ],
-    disabled: true,
   },
   {
     title: "Construction & Repair", icon: "Hammer",
     children: [ { title: "Work Orders", path: "/ops/maintenance/work-orders", icon: "Hammer" } ],
-    disabled: true,
   },
   { 
     title: "Reports", 
@@ -96,27 +71,25 @@ const NAV: NavParent[] = [
       { title: "Templates", path: "/reports/templates", icon: "FileText" },
     ]
   },
-  { title: "Growth", icon: "PieChart", children: [{ title: "Marketing", path: "/growth/marketing", icon: "PieChart" }], disabled: true },
+  { title: "Growth", icon: "PieChart", children: [{ title: "Marketing", path: "/growth/marketing", icon: "PieChart" }] },
   {
     title: "Systems", icon: "Settings",
     children: [ 
+      { title: "Settings", path: "/system/settings", icon: "Settings" },
       { title: "Integrations", path: "/systems/integrations", icon: "Link2" },
     ],
   },
   {
     title: "Data Management", icon: "Database",
     children: [ { title: "Sync Audit", path: "/data/sync-audit", icon: "ClipboardList" } ],
-    disabled: true,
   },
   {
     title: "Investor Portal", icon: "PieChart",
     children: [ { title: "Dashboard", path: "/investor/dashboard", icon: "LayoutDashboard" } ],
-    disabled: true,
   },
   {
     title: "Integrations", icon: "Link2",
     children: [ { title: "Dropbox Files", path: "/integrations/dropbox", icon: "FolderOpen" } ],
-    disabled: true,
   },
 ];
 
@@ -160,26 +133,11 @@ export default function Sidebar() {
   const [location] = useLocation();
   const { collapsed, setCollapsed } = useCollapsed();
   const [expandedTitle, setExpandedTitle] = useState<string | null>(null);
-  const liveNav = useMemo(
-    () =>
-      NAV.map((item) => {
-        const liveChildren = item.children?.filter((child) => LIVE_ROUTES.has(child.path)) ?? [];
-        return {
-          ...item,
-          path: item.path && LIVE_ROUTES.has(item.path) ? item.path : undefined,
-          children: liveChildren,
-          disabled: item.disabled || (!item.path && liveChildren.length === 0),
-        };
-      }),
-    [],
-  );
 
   useEffect(() => {
-    const activeParent = liveNav.find(
-      (p) => p.children?.some((c) => location.startsWith(c.path)) || (p.path && location.startsWith(p.path)),
-    );
+    const activeParent = NAV.find(p => p.children?.some(c => location.startsWith(c.path)) || (p.path && location.startsWith(p.path)));
     setExpandedTitle(activeParent?.title || null);
-  }, [liveNav, location]);
+  }, [location]);
 
   const [flyOpen, setFlyOpen] = useState(false);
   const [flyTitle, setFlyTitle] = useState("");
@@ -255,20 +213,19 @@ export default function Sidebar() {
         </div>
 
         <nav className="ecc-scroll" role="list">
-          {liveNav.map((p) => {
+          {NAV.map((p) => {
             const ParentIcon = iconOf(p.icon);
             const hasKids = !!p.children?.length;
             const isExpanded = expandedTitle === p.title;
             const parentActive = isActive(p.path) || (hasKids && p.children!.some((c) => isActive(c.path)));
             const rowRef = useRef<HTMLDivElement | null>(null);
-            const isDisabled = p.disabled;
 
             const rowContent = (
               <div
                 className="ecc-row-inner"
                 onMouseEnter={() => {
                   hoverParent.current = true;
-                  if (collapsed && hasKids && !isDisabled && rowRef.current) scheduleOpen(p, rowRef.current.getBoundingClientRect());
+                  if (collapsed && hasKids && rowRef.current) scheduleOpen(p, rowRef.current.getBoundingClientRect());
                 }}
                 onMouseLeave={() => {
                   hoverParent.current = false;
@@ -279,11 +236,6 @@ export default function Sidebar() {
                 {!collapsed && (
                   <>
                     <span className="ecc-label">{p.title}</span>
-                    {isDisabled && (
-                      <span className="ml-auto rounded border border-[#8b7340] bg-[#3b3425] px-1.5 py-0.5 text-[8px] uppercase tracking-[0.08em] text-[#f0e2bd]">
-                        Soon
-                      </span>
-                    )}
                     {hasKids && <div className="ecc-caret">{isExpanded ? <Icons.ChevronDown size={16} /> : <Icons.ChevronRight size={16} />}</div>}
                   </>
                 )}
@@ -291,7 +243,7 @@ export default function Sidebar() {
             );
 
             // If it's a direct link with no children, the whole row is a Link.
-            if (p.path && !hasKids && !isDisabled) {
+            if (p.path && !hasKids) {
               return (
                 <div key={p.title} ref={rowRef}>
                   <Link href={p.path} className={`ecc-row ${parentActive ? "is-active" : ""}`}>
@@ -303,23 +255,15 @@ export default function Sidebar() {
 
             // If it has children, it's a div that toggles them.
             return (
-              <div
-                key={p.title}
-                ref={rowRef}
-                className={`ecc-row ${parentActive ? "is-active" : ""} ${isDisabled ? "opacity-60" : ""}`}
-                aria-disabled={isDisabled}
-              >
+              <div key={p.title} ref={rowRef} className={`ecc-row ${parentActive ? "is-active" : ""}`}>
                 <div
                     className="ecc-row-clickable"
-                    onClick={() => {
-                      if (isDisabled || !hasKids) return;
-                      setExpandedTitle(isExpanded ? null : p.title);
-                    }}
+                    onClick={() => setExpandedTitle(isExpanded ? null : p.title)}
                 >
                     {rowContent}
                 </div>
 
-                {!collapsed && hasKids && isExpanded && !isDisabled && (
+                {!collapsed && hasKids && isExpanded && (
                   <div className="ecc-children" role="group">
                     {p.children!.map((c) => {
                       const CIcon = iconOf(c.icon);

--- a/src/components/analytics/ActiveFilterSummary.tsx
+++ b/src/components/analytics/ActiveFilterSummary.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+export type ActiveFilterSummaryItem = {
+  key: string;
+  label: string;
+  value: React.ReactNode;
+};
+
+export default function ActiveFilterSummary({
+  title,
+  items,
+}: {
+  title: string;
+  items: ActiveFilterSummaryItem[];
+}) {
+  return (
+    <section className="rounded-2xl border border-[rgba(214,179,106,0.24)] bg-[linear-gradient(135deg,rgba(214,179,106,0.14),rgba(27,31,38,0.96)_30%,rgba(11,14,18,1))] p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[#d6b36a]">{title}</div>
+          <div className="mt-2 text-sm text-[#d7dbe3]">Visible active scope for the current ECC surface.</div>
+        </div>
+        <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#d6b36a]">{items.length} filters</div>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {items.map((item) => (
+          <div key={item.key} className="rounded-full border border-[rgba(255,255,255,0.08)] bg-black/35 px-3 py-2 text-xs text-white">
+            <span className="font-bold uppercase tracking-[0.16em] text-[#d6b36a]">{item.label}</span>
+            <span className="ml-2 text-[#d7dbe3]">{item.value}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/analytics/KpiStrip.tsx
+++ b/src/components/analytics/KpiStrip.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+export type KpiStripMetric = {
+  key: string;
+  label: string;
+  value: React.ReactNode;
+  helper: string;
+};
+
+export default function KpiStrip({
+  title,
+  items,
+}: {
+  title: string;
+  items: KpiStripMetric[];
+}) {
+  return (
+    <section className="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[linear-gradient(180deg,rgba(255,255,255,0.03),rgba(27,31,38,0.98))] p-4 shadow-[0_16px_44px_rgba(0,0,0,0.24)]">
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-[10px] font-bold uppercase tracking-[0.18em] text-[#d6b36a]">{title}</div>
+        <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#a5adba]">{items.length} metrics</div>
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        {items.map((item) => (
+          <div key={item.key} className="rounded-[18px] border border-[rgba(255,255,255,0.08)] bg-black/25 p-4">
+            <div className="text-[10px] font-bold uppercase tracking-[0.16em] text-[#a5adba]">{item.label}</div>
+            <div className="mt-3 text-2xl font-semibold tracking-tight text-white">{item.value}</div>
+            <div className="mt-2 text-xs leading-5 text-[#a5adba]">{item.helper}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/features/dashboard/dashboardMetricRegistry.ts
+++ b/src/features/dashboard/dashboardMetricRegistry.ts
@@ -1,0 +1,60 @@
+import { formatCurrencyFromCents, formatNumber, formatPercent, BLANK } from "@/lib/format";
+import type { DashboardKpis } from "@/features/dashboard/hooks/useDashboardKpis";
+
+type DashboardMetricDefinition = {
+  key: string;
+  label: string;
+  helper: string;
+  render: (data: DashboardKpis) => string;
+};
+
+const METRICS: DashboardMetricDefinition[] = [
+  {
+    key: "properties",
+    label: "Properties",
+    helper: "Total properties currently in the portfolio command surface.",
+    render: (data) => formatNumber(data.propertiesTotal ?? 0),
+  },
+  {
+    key: "units",
+    label: "Units",
+    helper: "Total units represented by the live portfolio summary feed.",
+    render: (data) => formatNumber(data.unitsTotal ?? 0),
+  },
+  {
+    key: "occupancy",
+    label: "Occupancy",
+    helper: "Live portfolio occupancy pulled into the dashboard summary route.",
+    render: (data) => (data.occupancyRate !== undefined ? formatPercent(data.occupancyRate, 1, "fraction") : BLANK),
+  },
+  {
+    key: "revenue_30d",
+    label: "Revenue (30d)",
+    helper: "Recent 30-day revenue shown for war-room level command readout.",
+    render: (data) => formatCurrencyFromCents(data.revenue30dCents ?? 0),
+  },
+];
+
+export function buildDashboardMetricCards(data: DashboardKpis) {
+  return METRICS.map((metric) => ({
+    key: metric.key,
+    label: metric.label,
+    helper: metric.helper,
+    value: metric.render(data),
+  }));
+}
+
+export function buildDashboardFilterSummary(data: DashboardKpis) {
+  const seriesCount = data.series?.length ?? 0;
+
+  return [
+    { key: "scope", label: "Scope", value: "Portfolio command" },
+    { key: "window", label: "Window", value: "30 days" },
+    { key: "series", label: "Trend points", value: formatNumber(seriesCount) },
+    {
+      key: "occupancy",
+      label: "Occupancy",
+      value: data.occupancyRate !== undefined ? formatPercent(data.occupancyRate, 1, "fraction") : BLANK,
+    },
+  ];
+}

--- a/src/features/dashboard/pages/DashboardPage.tsx
+++ b/src/features/dashboard/pages/DashboardPage.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { useDashboardKpis } from "@/features/dashboard/hooks/useDashboardKpis";
-import { KpiCard } from "@/features/dashboard/components/KpiCard";
 import { Sparkline } from "@/features/dashboard/components/Sparkline";
-import { DASHBOARD_KPI_TEST_IDS } from "@/features/dashboard/constants/testIds";
+import KpiStrip from "@/components/analytics/KpiStrip";
+import ActiveFilterSummary from "@/components/analytics/ActiveFilterSummary";
+import { buildDashboardFilterSummary, buildDashboardMetricCards } from "@/features/dashboard/dashboardMetricRegistry";
 
 function toPct(n?: number) {
   return Number.isFinite(n!) ? n! * 100 : undefined;
@@ -10,20 +11,19 @@ function toPct(n?: number) {
 
 export default function DashboardPage() {
   const { data, isLoading, isError } = useDashboardKpis();
-  const occPct = toPct(data?.occupancyRate);
   const series = (data?.series ?? []).map(p => ({ date: p.date, value: toPct(p.occupancy)! }));
 
   if (isLoading) return <div className="p-6">Loading dashboard…</div>;
   if (isError)   return <div className="p-6">Failed to load dashboard.</div>;
+  if (!data) return <div className="p-6">No dashboard data available.</div>;
+
+  const metricCards = buildDashboardMetricCards(data);
+  const filterSummary = buildDashboardFilterSummary(data);
 
   return (
     <div className="dashboard-grid p-6 space-y-6">
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <KpiCard label="Properties" value={data?.propertiesTotal} testId={DASHBOARD_KPI_TEST_IDS.PROPERTIES} />
-        <KpiCard label="Units" value={data?.unitsTotal} testId={DASHBOARD_KPI_TEST_IDS.UNITS} />
-        <KpiCard label="Occupancy" value={occPct} decimals={1} testId={DASHBOARD_KPI_TEST_IDS.OCCUPANCY} />
-        <KpiCard label="Revenue (30d)" value={(data?.revenue30dCents ?? 0) / 100} decimals={0} testId={DASHBOARD_KPI_TEST_IDS.REVENUE} />
-      </div>
+      <KpiStrip title="War-Room Metric Rail" items={metricCards} />
+      <ActiveFilterSummary title="Active Dashboard Scope" items={filterSummary} />
       <Sparkline data={series} />
     </div>
   );

--- a/src/pages/portfolio/Properties.tsx
+++ b/src/pages/portfolio/Properties.tsx
@@ -2,7 +2,9 @@ import React, { useMemo, useState } from "react";
 import FilterBar from "../../components/FilterBar";
 import DataTable, { Column } from "../../components/DataTable";
 import { useAllProperties } from "../../lib/ecc-resolvers";
-import { formatNumber, formatPercent, formatCurrencyFromCents, BLANK } from "@/lib/format";
+import { formatNumber, formatPercent, BLANK } from "@/lib/format";
+import KpiStrip from "@/components/analytics/KpiStrip";
+import ActiveFilterSummary from "@/components/analytics/ActiveFilterSummary";
 
 type PropertyRow = {
   id: string;
@@ -50,6 +52,41 @@ export default function Properties() {
     { key: "market", header: "Market", width: 140 },
   ];
 
+  const occupancyAverage = useMemo(() => {
+    if (!data || data.length === 0) return null;
+    const numeric = data
+      .map((prop: any) => Number(prop.occupancy_pct))
+      .filter((value: number) => Number.isFinite(value));
+    if (numeric.length === 0) return null;
+    return numeric.reduce((sum: number, value: number) => sum + value, 0) / numeric.length;
+  }, [data]);
+
+  const rankedMarkets = useMemo(() => {
+    const counts = new Map<string, number>();
+    rows.forEach((row) => {
+      if (!row.market || row.market === BLANK) return;
+      counts.set(row.market, (counts.get(row.market) ?? 0) + 1);
+    });
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 1)
+      .map(([market, count]) => `${market} (${count})`)[0] ?? BLANK;
+  }, [rows]);
+
+  const propertyMetrics = [
+    { key: "visible_properties", label: "Visible Properties", value: formatNumber(rows.length), helper: "Current property rows after applying the live table search scope." },
+    { key: "portfolio_total", label: "Portfolio Total", value: formatNumber(data?.length ?? 0), helper: "Total properties returned from the portfolio resolver before search narrowing." },
+    { key: "avg_occupancy", label: "Avg Occupancy", value: occupancyAverage !== null ? formatPercent(occupancyAverage, 0, "percent") : BLANK, helper: "Average occupancy across properties currently loaded into the table." },
+    { key: "top_market", label: "Top Market", value: rankedMarkets, helper: "Most represented market inside the current visible property slice." },
+  ];
+
+  const activeSummary = [
+    { key: "search", label: "Search", value: q.trim() || "All properties" },
+    { key: "results", label: "Results", value: `${rows.length}/${data?.length ?? 0}` },
+    { key: "scope", label: "Scope", value: "Property table" },
+    { key: "drilldown", label: "Drill-down", value: "Property card route" },
+  ];
+
   return (
     <section className="ecc-page">
       <FilterBar 
@@ -59,6 +96,10 @@ export default function Properties() {
         createLabel="Add Property" 
         onCreate={() => alert("Create Property")} 
       />
+      <div className="space-y-4 pb-4">
+        <KpiStrip title="Portfolio Metric Rail" items={propertyMetrics} />
+        <ActiveFilterSummary title="Active Property Scope" items={activeSummary} />
+      </div>
       <DataTable 
         columns={columns} 
         rows={rows} 


### PR DESCRIPTION
Root purpose:

selectively reuse Superset-inspired Altus patterns without turning apps into generic BI dashboards

What changed:

- add a dashboard KPI strip
- add a dashboard scope summary
- add a properties KPI strip
- add a properties active scope summary
- add a dashboard metric registry

Scope boundaries:

- compact KPI strip only
- visible active filter/state summary only
- metric contract registry wiring only

Explicit non-goals:

- no permalink state
- no ranked summary lists
- no scoped drill-down triggers
- no backend changes
- no Superset runtime dependency

Notes:

- no backend change required
- pre-existing typecheck debt is unrelated to this slice