### PR TITLE
Implementation Slice 1: extend Type A command surface to units

### DIFF
--- a/src/features/command-surface/CanonicalDenseTableShell.tsx
+++ b/src/features/command-surface/CanonicalDenseTableShell.tsx
@@ -9,11 +9,12 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import { ArrowUpDown, Building2, MapPinned, Percent, Rows3 } from "lucide-react";
-import { PropertyCommandRow } from "./types";
+import { CommandSurfaceConfig, CommandSurfaceRow } from "./types";
 import "@/styles/command-surface.css";
 
 type Props = {
-  rows: PropertyCommandRow[];
+  rows: CommandSurfaceRow[];
+  config: CommandSurfaceConfig;
   loading?: boolean;
   error?: string;
   search: string;
@@ -25,6 +26,7 @@ type Props = {
 
 export default function CanonicalDenseTableShell({
   rows,
+  config,
   loading,
   error,
   search,
@@ -33,9 +35,9 @@ export default function CanonicalDenseTableShell({
   selectedIds,
   onSelectionChange,
 }: Props) {
-  const [sorting, setSorting] = useState<SortingState>([{ id: "name", desc: false }]);
+  const [sorting, setSorting] = useState<SortingState>([{ id: "primary", desc: false }]);
 
-  const columns = useMemo<ColumnDef<PropertyCommandRow>[]>(
+  const columns = useMemo<ColumnDef<CommandSurfaceRow>[]>(
     () => [
       {
         id: "select",
@@ -43,10 +45,8 @@ export default function CanonicalDenseTableShell({
           <input
             type="checkbox"
             checked={rows.length > 0 && selectedIds.length === rows.length}
-            onChange={(event) =>
-              onSelectionChange(event.target.checked ? rows.map((row) => row.id) : [])
-            }
-            aria-label="Select all visible properties"
+            onChange={(event) => onSelectionChange(event.target.checked ? rows.map((row) => row.id) : [])}
+            aria-label={`Select all visible ${config.entityPluralLabel.toLowerCase()}`}
           />
         ),
         cell: ({ row }) => {
@@ -63,20 +63,20 @@ export default function CanonicalDenseTableShell({
                     : selectedIds.filter((id) => id !== rowId),
                 )
               }
-              aria-label={`Select property ${row.original.name}`}
+              aria-label={`Select ${config.entityLabel.toLowerCase()} ${row.original.primary}`}
             />
           );
         },
         enableSorting: false,
       },
       { accessorKey: "id", header: "ID" },
-      { accessorKey: "name", header: "Property" },
-      { accessorKey: "address", header: "Address" },
-      { accessorKey: "units", header: "Units" },
-      { accessorKey: "occupancy", header: "Occupancy" },
-      { accessorKey: "market", header: "Market" },
+      { accessorKey: "primary", header: config.entityLabel },
+      { accessorKey: "secondary", header: "Context" },
+      { accessorKey: "metricA", header: config.metricALabel },
+      { accessorKey: "metricB", header: config.metricBLabel },
+      { accessorKey: "segment", header: config.segmentLabel },
     ],
-    [onSelectionChange, rows, selectedIds],
+    [config, onSelectionChange, rows, selectedIds],
   );
 
   const table = useReactTable({
@@ -92,10 +92,11 @@ export default function CanonicalDenseTableShell({
       if (!needle) return true;
       const haystack = [
         row.original.id,
-        row.original.name,
-        row.original.address,
-        row.original.occupancy,
-        row.original.market,
+        row.original.primary,
+        row.original.secondary,
+        row.original.metricA,
+        row.original.metricB,
+        row.original.segment,
       ]
         .join(" ")
         .toLowerCase();
@@ -108,11 +109,11 @@ export default function CanonicalDenseTableShell({
 
   const visibleRows = table.getRowModel().rows;
   const selectedRows = rows.filter((row) => selectedIds.includes(row.id));
-  const averageOccupancy = rows.length
-    ? Math.round(
-        rows.reduce((sum, row) => sum + Number.parseInt(row.occupancy.replace("%", ""), 10), 0) /
-          rows.length,
-      )
+  const metricBNumbers = rows
+    .map((row) => Number.parseFloat(row.metricB.replace(/[^0-9.-]/g, "")))
+    .filter((value) => Number.isFinite(value));
+  const averageMetricB = metricBNumbers.length
+    ? Math.round(metricBNumbers.reduce((sum, value) => sum + value, 0) / metricBNumbers.length)
     : 0;
 
   return (
@@ -120,10 +121,8 @@ export default function CanonicalDenseTableShell({
       <div className="ecc-command-surface__context">
         <div>
           <p className="ecc-command-surface__eyebrow">T0 Context</p>
-          <h1 className="ecc-command-surface__title">Properties Command Surface</h1>
-          <p className="ecc-command-surface__subtitle">
-            Type A zoning over the existing property resolver, using only current ECC collection fields.
-          </p>
+          <h1 className="ecc-command-surface__title">{config.title}</h1>
+          <p className="ecc-command-surface__subtitle">{config.subtitle}</p>
         </div>
         <div className="ecc-command-surface__stats">
           <div className="ecc-command-stat">
@@ -132,11 +131,11 @@ export default function CanonicalDenseTableShell({
           </div>
           <div className="ecc-command-stat">
             <Percent size={16} />
-            <span>{averageOccupancy}% avg occupancy</span>
+            <span>{averageMetricB}{config.metricBLabel.toLowerCase().includes("occupancy") ? "% avg" : " avg"}</span>
           </div>
           <div className="ecc-command-stat">
             <MapPinned size={16} />
-            <span>{new Set(rows.map((row) => row.market)).size} markets</span>
+            <span>{new Set(rows.map((row) => row.segment)).size} {config.segmentSummaryLabel}</span>
           </div>
         </div>
       </div>
@@ -144,15 +143,15 @@ export default function CanonicalDenseTableShell({
       <div className="ecc-command-surface__toolbar">
         <div className="ecc-command-surface__toolbar-copy">
           <p className="ecc-command-surface__eyebrow">T2 Filters / Search</p>
-          <span>Search current rows and select properties for the optional triage rail.</span>
+          <span>{config.tableSummary}</span>
         </div>
         <label className="ecc-command-search">
-          <span className="sr-only">Search properties</span>
+          <span className="sr-only">{config.searchLabel}</span>
           <input
             ref={searchInputRef}
             value={search}
             onChange={(event) => onSearchChange(event.target.value)}
-            placeholder="Search property, address, id, or market"
+            placeholder={config.searchPlaceholder}
           />
         </label>
       </div>
@@ -165,11 +164,11 @@ export default function CanonicalDenseTableShell({
           </div>
           <div className="ecc-command-surface__selected">
             <Building2 size={16} />
-            <span>{selectedRows.length} selected</span>
+            <span>{selectedRows.length} {config.selectedLabel}</span>
           </div>
         </div>
 
-        {loading ? <div className="ecc-command-empty-panel">Loading property command surface…</div> : null}
+        {loading ? <div className="ecc-command-empty-panel">Loading {config.entityLabel.toLowerCase()} command surface…</div> : null}
         {!loading && error ? <div className="ecc-command-empty-panel">{error}</div> : null}
         {!loading && !error ? (
           <div className="ecc-command-table-shell">
@@ -208,7 +207,7 @@ export default function CanonicalDenseTableShell({
               </tbody>
             </table>
             {visibleRows.length === 0 ? (
-              <div className="ecc-command-empty-panel">No properties match the current search.</div>
+              <div className="ecc-command-empty-panel">No {config.entityPluralLabel.toLowerCase()} match the current search.</div>
             ) : null}
           </div>
         ) : null}

--- a/src/features/command-surface/EccCommandPalette.tsx
+++ b/src/features/command-surface/EccCommandPalette.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Command } from "cmdk";
 import { Building2, Command as CommandIcon, LayoutDashboard, Link2, Search, Shield } from "lucide-react";
 import { useLocation } from "wouter";
+import { CommandSurfaceConfig } from "./types";
 import "@/styles/command-surface.css";
 
 type CommandItem = {
@@ -14,10 +15,11 @@ type CommandItem = {
 };
 
 type Props = {
-  onFocusPropertiesSearch?: () => void;
+  config?: CommandSurfaceConfig;
+  onFocusSearch?: () => void;
 };
 
-export default function EccCommandPalette({ onFocusPropertiesSearch }: Props) {
+export default function EccCommandPalette({ config, onFocusSearch }: Props) {
   const [open, setOpen] = useState(false);
   const [, navigate] = useLocation();
 
@@ -43,11 +45,11 @@ export default function EccCommandPalette({ onFocusPropertiesSearch }: Props) {
         path: "/dashboard",
       },
       {
-        id: "properties",
-        label: "Open Properties",
-        hint: "Go to Type A portfolio proof surface",
+        id: "surface",
+        label: config ? `Open ${config.entityPluralLabel}` : "Open Properties",
+        hint: config ? `Go to ${config.title}` : "Go to Type A portfolio proof surface",
         icon: <Building2 size={16} />,
-        path: "/portfolio/properties",
+        path: config?.routePath ?? "/portfolio/properties",
       },
       {
         id: "integrations",
@@ -58,10 +60,10 @@ export default function EccCommandPalette({ onFocusPropertiesSearch }: Props) {
       },
       {
         id: "focus-search",
-        label: "Focus Property Search",
+        label: config?.focusCommandLabel ?? "Focus Property Search",
         hint: "Jump to the T2 search surface",
         icon: <Search size={16} />,
-        action: () => onFocusPropertiesSearch?.(),
+        action: () => onFocusSearch?.(),
       },
       {
         id: "dropbox",
@@ -71,7 +73,7 @@ export default function EccCommandPalette({ onFocusPropertiesSearch }: Props) {
         path: "/integrations/dropbox",
       },
     ],
-    [onFocusPropertiesSearch],
+    [config, onFocusSearch],
   );
 
   function runItem(item: CommandItem) {
@@ -109,11 +111,7 @@ export default function EccCommandPalette({ onFocusPropertiesSearch }: Props) {
             <Command.Empty className="ecc-command-empty">No matching ECC commands.</Command.Empty>
             <Command.Group heading="Surfaces" className="ecc-command-group">
               {items.map((item) => (
-                <Command.Item
-                  key={item.id}
-                  className="ecc-command-item"
-                  onSelect={() => runItem(item)}
-                >
+                <Command.Item key={item.id} className="ecc-command-item" onSelect={() => runItem(item)}>
                   <span className="ecc-command-item__icon">{item.icon}</span>
                   <span className="ecc-command-item__copy">
                     <span className="ecc-command-item__label">{item.label}</span>

--- a/src/features/command-surface/TriageBoardShell.tsx
+++ b/src/features/command-surface/TriageBoardShell.tsx
@@ -15,7 +15,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { AlertTriangle, Eye, ShieldAlert } from "lucide-react";
-import { PropertyCommandRow } from "./types";
+import { CommandSurfaceConfig, CommandSurfaceRow } from "./types";
 import "@/styles/command-surface.css";
 
 type LaneKey = "watchlist" | "review" | "escalate";
@@ -39,11 +39,12 @@ const LANE_META: Record<LaneKey, { title: string; icon: React.ReactNode; hint: s
 };
 
 type Props = {
-  items: PropertyCommandRow[];
+  items: CommandSurfaceRow[];
+  config: CommandSurfaceConfig;
 };
 
 type SortableCardProps = {
-  item: PropertyCommandRow;
+  item: CommandSurfaceRow;
 };
 
 function SortableCard({ item }: SortableCardProps) {
@@ -54,23 +55,16 @@ function SortableCard({ item }: SortableCardProps) {
   };
 
   return (
-    <button
-      ref={setNodeRef}
-      style={style}
-      type="button"
-      className="ecc-triage-card"
-      {...attributes}
-      {...listeners}
-    >
-      <span className="ecc-triage-card__title">{item.name}</span>
-      <span className="ecc-triage-card__meta">#{item.id} • {item.occupancy} • {item.market}</span>
+    <button ref={setNodeRef} style={style} type="button" className="ecc-triage-card" {...attributes} {...listeners}>
+      <span className="ecc-triage-card__title">{item.primary}</span>
+      <span className="ecc-triage-card__meta">#{item.id} • {item.metricB} • {item.segment}</span>
     </button>
   );
 }
 
-export default function TriageBoardShell({ items }: Props) {
+export default function TriageBoardShell({ items, config }: Props) {
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
-  const [lanes, setLanes] = useState<Record<LaneKey, PropertyCommandRow[]>>({
+  const [lanes, setLanes] = useState<Record<LaneKey, CommandSurfaceRow[]>>({
     watchlist: items,
     review: [],
     escalate: [],
@@ -86,10 +80,7 @@ export default function TriageBoardShell({ items }: Props) {
     }));
   }, [items]);
 
-  const allIds = useMemo(
-    () => Object.values(lanes).flatMap((lane) => lane.map((item) => item.id)),
-    [lanes],
-  );
+  const allIds = useMemo(() => Object.values(lanes).flatMap((lane) => lane.map((item) => item.id)), [lanes]);
 
   function findLane(itemId: string): LaneKey | undefined {
     return (Object.keys(lanes) as LaneKey[]).find((lane) => lanes[lane].some((item) => item.id === itemId));
@@ -133,7 +124,7 @@ export default function TriageBoardShell({ items }: Props) {
     return (
       <aside className="ecc-triage-shell ecc-object">
         <p className="ecc-command-surface__eyebrow">T5 Drilldown Rail</p>
-        <div className="ecc-command-empty-panel">Select properties from the dense table to start local triage.</div>
+        <div className="ecc-command-empty-panel">{config.triageEmptyLabel}</div>
       </aside>
     );
   }
@@ -143,7 +134,7 @@ export default function TriageBoardShell({ items }: Props) {
       <div className="ecc-triage-shell__header">
         <div>
           <p className="ecc-command-surface__eyebrow">T5 Optional Drilldown Rail</p>
-          <h2 className="ecc-triage-shell__title">Portfolio Triage</h2>
+          <h2 className="ecc-triage-shell__title">{config.triageTitle}</h2>
         </div>
         <span className="ecc-triage-shell__count">{allIds.length} cards in motion</span>
       </div>
@@ -164,9 +155,7 @@ export default function TriageBoardShell({ items }: Props) {
                   {lanes[lane].map((item) => (
                     <SortableCard key={item.id} item={item} />
                   ))}
-                  {lanes[lane].length === 0 ? (
-                    <div className="ecc-triage-lane__empty">Drop selected properties here.</div>
-                  ) : null}
+                  {lanes[lane].length === 0 ? <div className="ecc-triage-lane__empty">Drop selected rows here.</div> : null}
                 </div>
               </SortableContext>
             </div>

--- a/src/features/command-surface/types.ts
+++ b/src/features/command-surface/types.ts
@@ -1,8 +1,27 @@
-export type PropertyCommandRow = {
+export type CommandSurfaceRow = {
   id: string;
-  name: string;
-  address: string;
-  units: number;
-  occupancy: string;
-  market: string;
+  primary: string;
+  secondary: string;
+  metricA: string;
+  metricB: string;
+  segment: string;
+};
+
+export type CommandSurfaceConfig = {
+  entityLabel: string;
+  entityPluralLabel: string;
+  routePath: string;
+  title: string;
+  subtitle: string;
+  searchPlaceholder: string;
+  searchLabel: string;
+  tableSummary: string;
+  selectedLabel: string;
+  metricALabel: string;
+  metricBLabel: string;
+  segmentLabel: string;
+  segmentSummaryLabel: string;
+  triageTitle: string;
+  triageEmptyLabel: string;
+  focusCommandLabel: string;
 };

--- a/src/pages/portfolio/Properties.tsx
+++ b/src/pages/portfolio/Properties.tsx
@@ -4,7 +4,26 @@ import { BLANK, formatPercent } from "@/lib/format";
 import CanonicalDenseTableShell from "@/features/command-surface/CanonicalDenseTableShell";
 import EccCommandPalette from "@/features/command-surface/EccCommandPalette";
 import TriageBoardShell from "@/features/command-surface/TriageBoardShell";
-import { PropertyCommandRow } from "@/features/command-surface/types";
+import { CommandSurfaceConfig, CommandSurfaceRow } from "@/features/command-surface/types";
+
+const PROPERTY_SURFACE_CONFIG: CommandSurfaceConfig = {
+  entityLabel: "Property",
+  entityPluralLabel: "Properties",
+  routePath: "/portfolio/properties",
+  title: "Properties Command Surface",
+  subtitle: "Type A zoning over the existing property resolver, using only current ECC collection fields.",
+  searchPlaceholder: "Search property, address, id, or market",
+  searchLabel: "Search properties",
+  tableSummary: "Search current rows and select properties for the optional triage rail.",
+  selectedLabel: "selected",
+  metricALabel: "Units",
+  metricBLabel: "Occupancy",
+  segmentLabel: "Market",
+  segmentSummaryLabel: "markets",
+  triageTitle: "Portfolio Triage",
+  triageEmptyLabel: "Select properties from the dense table to start local triage.",
+  focusCommandLabel: "Focus Property Search",
+};
 
 export default function Properties() {
   const [q, setQ] = useState("");
@@ -14,25 +33,20 @@ export default function Properties() {
 
   const rows = useMemo(() => {
     if (!data) return [];
-    
-    // Map API data to table format
-    const mapped: PropertyCommandRow[] = data.map((prop: any) => ({
+
+    const mapped: CommandSurfaceRow[] = data.map((prop: any) => ({
       id: String(prop.id),
-      name: prop.name ?? prop.label ?? `Property ${prop.id}`,
-      address: [prop.street_1, prop.city, prop.state].filter(Boolean).join(", ") ?? BLANK,
-      units: prop.units !== null && prop.units !== undefined ? prop.units : 0,
-      occupancy: prop.occupancy_pct ? formatPercent(prop.occupancy_pct, 0, "percent") : BLANK,
-      market: prop.city ?? prop.state ?? BLANK
+      primary: prop.name ?? prop.label ?? `Property ${prop.id}`,
+      secondary: [prop.street_1, prop.city, prop.state].filter(Boolean).join(", ") ?? BLANK,
+      metricA: String(prop.units !== null && prop.units !== undefined ? prop.units : 0),
+      metricB: prop.occupancy_pct ? formatPercent(prop.occupancy_pct, 0, "percent") : BLANK,
+      segment: prop.city ?? prop.state ?? BLANK,
     }));
 
-    // Apply search filter
-    const t = q.trim().toLowerCase();
-    if (!t) return mapped;
-    return mapped.filter(r =>
-      r.name.toLowerCase().includes(t) ||
-      r.address.toLowerCase().includes(t) ||
-      r.id.toLowerCase().includes(t) ||
-      r.market.toLowerCase().includes(t)
+    const needle = q.trim().toLowerCase();
+    if (!needle) return mapped;
+    return mapped.filter((row) =>
+      [row.primary, row.secondary, row.id, row.segment].join(" ").toLowerCase().includes(needle),
     );
   }, [data, q]);
   const selectedRows = rows.filter((row) => selectedIds.includes(row.id));
@@ -41,9 +55,10 @@ export default function Properties() {
     <section className="ecc-page">
       <div className="ecc-command-surface-layout">
         <div>
-          <EccCommandPalette onFocusPropertiesSearch={() => searchInputRef.current?.focus()} />
+          <EccCommandPalette config={PROPERTY_SURFACE_CONFIG} onFocusSearch={() => searchInputRef.current?.focus()} />
           <CanonicalDenseTableShell
             rows={rows}
+            config={PROPERTY_SURFACE_CONFIG}
             loading={isLoading || (isFetching && rows.length === 0)}
             error={error ? String(error) : undefined}
             search={q}
@@ -53,7 +68,7 @@ export default function Properties() {
             onSelectionChange={(ids) => setSelectedIds(Array.from(new Set(ids)))}
           />
         </div>
-        <TriageBoardShell items={selectedRows} />
+        <TriageBoardShell items={selectedRows} config={PROPERTY_SURFACE_CONFIG} />
       </div>
     </section>
   );

--- a/src/pages/portfolio/Units.tsx
+++ b/src/pages/portfolio/Units.tsx
@@ -1,72 +1,75 @@
-import React, { useMemo, useState } from "react";
-import FilterBar from "../../components/FilterBar";
-import DataTable, { Column } from "../../components/DataTable";
+import React, { useMemo, useRef, useState } from "react";
 import { useAllUnits } from "../../lib/ecc-resolvers";
-import { formatNumber, formatPercent, formatCurrencyFromCents, BLANK } from "@/lib/format";
+import { formatCurrencyFromCents, BLANK } from "@/lib/format";
+import CanonicalDenseTableShell from "@/features/command-surface/CanonicalDenseTableShell";
+import EccCommandPalette from "@/features/command-surface/EccCommandPalette";
+import TriageBoardShell from "@/features/command-surface/TriageBoardShell";
+import { CommandSurfaceConfig, CommandSurfaceRow } from "@/features/command-surface/types";
 
-type UnitRow = {
-  id: string;
-  property: string;
-  unit: string;
-  beds: number;
-  baths: number;
-  status: "Occupied" | "Vacant" | "Notice";
-  rent: string;
+const UNIT_SURFACE_CONFIG: CommandSurfaceConfig = {
+  entityLabel: "Unit",
+  entityPluralLabel: "Units",
+  routePath: "/portfolio/units",
+  title: "Units Command Surface",
+  subtitle: "Type A zoning over the existing unit resolver, keeping the rollout route-safe and limited to current resolver fields.",
+  searchPlaceholder: "Search unit, property, status, or market rent",
+  searchLabel: "Search units",
+  tableSummary: "Search current rows and select units for local-only triage without adding persistence.",
+  selectedLabel: "selected",
+  metricALabel: "Mix",
+  metricBLabel: "Market Rent",
+  segmentLabel: "Status",
+  segmentSummaryLabel: "statuses",
+  triageTitle: "Unit Triage",
+  triageEmptyLabel: "Select units from the dense table to start local triage.",
+  focusCommandLabel: "Focus Unit Search",
 };
 
 export default function Units() {
   const [q, setQ] = useState("");
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const { data, isLoading, isFetching, error } = useAllUnits();
 
   const rows = useMemo(() => {
     if (!data) return [];
-    
-    // Map API data to table format
-    const mapped: UnitRow[] = data.map((unit: any) => ({
+
+    const mapped: CommandSurfaceRow[] = data.map((unit: any) => ({
       id: String(unit.id),
-      property: unit.property_name ?? BLANK,
-      unit: unit.label ?? unit.unit_number ?? `Unit ${unit.id}`,
-      beds: unit.beds !== null && unit.beds !== undefined ? unit.beds : 0,
-      baths: unit.baths !== null && unit.baths !== undefined ? unit.baths : 0,
-      status: unit.status ?? "Vacant",
-      rent: unit.market_rent_cents ? formatCurrencyFromCents(unit.market_rent_cents) : BLANK
+      primary: unit.label ?? unit.unit_number ?? `Unit ${unit.id}`,
+      secondary: unit.property_name ?? BLANK,
+      metricA: `${unit.beds !== null && unit.beds !== undefined ? unit.beds : 0} bd / ${unit.baths !== null && unit.baths !== undefined ? unit.baths : 0} ba`,
+      metricB: unit.market_rent_cents ? formatCurrencyFromCents(unit.market_rent_cents) : BLANK,
+      segment: unit.status ?? "Vacant",
     }));
 
-    // Apply search filter
-    const t = q.trim().toLowerCase();
-    if (!t) return mapped;
-    return mapped.filter(r =>
-      r.property.toLowerCase().includes(t) ||
-      r.unit.toLowerCase().includes(t) ||
-      r.status.toLowerCase().includes(t)
+    const needle = q.trim().toLowerCase();
+    if (!needle) return mapped;
+    return mapped.filter((row) =>
+      [row.primary, row.secondary, row.metricB, row.segment].join(" ").toLowerCase().includes(needle),
     );
   }, [data, q]);
-
-  const columns: Column<UnitRow>[] = [
-    { key: "unit", header: "Unit", width: 100 },
-    { key: "property", header: "Property" },
-    { key: "beds", header: "Beds", width: 80 },
-    { key: "baths", header: "Baths", width: 90 },
-    { key: "status", header: "Status", width: 120 },
-    { key: "rent", header: "Market Rent", width: 140 },
-  ];
+  const selectedRows = rows.filter((row) => selectedIds.includes(row.id));
 
   return (
     <section className="ecc-page">
-      <FilterBar 
-        title="Units" 
-        value={q} 
-        onChange={setQ} 
-        placeholder="Search units / property / status" 
-      />
-      <DataTable 
-        columns={columns} 
-        rows={rows} 
-        loading={isLoading || (isFetching && rows.length === 0)}
-        error={error ? String(error) : undefined}
-        rowHref={(r) => `/card/unit/${r.id}`}
-        getRowId={(r) => r.id}
-      />
+      <div className="ecc-command-surface-layout">
+        <div>
+          <EccCommandPalette config={UNIT_SURFACE_CONFIG} onFocusSearch={() => searchInputRef.current?.focus()} />
+          <CanonicalDenseTableShell
+            rows={rows}
+            config={UNIT_SURFACE_CONFIG}
+            loading={isLoading || (isFetching && rows.length === 0)}
+            error={error ? String(error) : undefined}
+            search={q}
+            onSearchChange={setQ}
+            searchInputRef={searchInputRef}
+            selectedIds={selectedIds}
+            onSelectionChange={(ids) => setSelectedIds(Array.from(new Set(ids)))}
+          />
+        </div>
+        <TriageBoardShell items={selectedRows} config={UNIT_SURFACE_CONFIG} />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- generalize the Type A command-surface primitives so they can be reused safely across portfolio surfaces
- keep Properties on the same shell pattern while rolling the next surface out to Units
- add route-safe command actions and local-only triage for the Units resolver using current fields only

## Boundaries
- no adapter changes
- no backend drift
- no contract invention
- no persistence added for triage