### PR TITLE
Mark ECC shared project-source deletion safe

### DIFF
--- a/docs/governance/SHARED_PROJECT_SOURCE_REMOVAL_READINESS_2026-08-06.md
+++ b/docs/governance/SHARED_PROJECT_SOURCE_REMOVAL_READINESS_2026-08-06.md
@@ -1,0 +1,33 @@
+# Shared Project Source Removal Readiness — 2026-08-06
+
+Status: SAFE TO REMOVE FROM SHARED CHATGPT PROJECT SOURCES  
+Repository: `Altus-Realty-Group/Replit_Front_End_ECC`  
+Verified base: `5e5bd182f24c997dd743ccc5bca872ae2a64f4ff`
+
+## Scope
+
+This record governs removal of these uploaded/shared project-source files only:
+
+- `ecc_genesis_master_roadmap_v_6.md`
+- `ecc_recovery_md_files_copy_save_individually.md`
+
+It does not authorize deleting application source code, Git history, runtime data, databases, secrets, or local downloads.
+
+## Repository continuity
+
+ECC can be resumed from this repository without either uploaded file:
+
+1. `docs/roadmaps/README.md` identifies current roadmap authority.
+2. `docs/roadmaps/ECC_SUPERIORITY_IMPLEMENTATION_MASTER_PLAN_V1.md` contains the corrected product direction, architecture boundaries, delivery program, proof requirements, and next-worker pickup sequence.
+3. `AGENTS.md` contains repository-specific worker and safety instructions.
+4. Historical `docs/roadmaps/ECC_Frontend_Genesis_Rebuild.md` is provenance only and explicitly non-executable.
+
+## Supersession decision
+
+The uploaded roadmap's Genesis, Altus Core, fixed pipeline, and immutable architecture claims are obsolete. Genesis is not an Altus product or system. Control Plane replaced the former Altus Core identity/access concept, while Supabase/PostgreSQL remains a distinct data platform.
+
+The recovery bundle contains generic prompt/agent governance and stale platform-state fragments. It is not ECC product authority and is unnecessary for continuity.
+
+## Decision
+
+Removal of the two uploaded files from shared project sources is safe after this branch is merged. The user's separate downloaded copies remain an external recovery backup.

--- a/docs/roadmaps/ECC_SUPERIORITY_IMPLEMENTATION_MASTER_PLAN_V1.md
+++ b/docs/roadmaps/ECC_SUPERIORITY_IMPLEMENTATION_MASTER_PLAN_V1.md
@@ -1,6 +1,6 @@
 # ECC Superiority Implementation Master Plan V1
 
-Status: PROPOSED CANONICAL - pending merge and named Dion approval gates  
+Status: CANONICAL PLANNING AUTHORITY - merged through PR #103; implementation and mutation gates still require current authorization  
 Product owner: Dion DePaoli  
 Repository: `Altus-Realty-Group/Replit_Front_End_ECC`  
 Baseline audited: `main` at `15f670a09c7a0fc029ae8e417efaddd002ba61ec` on 2026-08-04

--- a/docs/roadmaps/README.md
+++ b/docs/roadmaps/README.md
@@ -1,8 +1,8 @@
 # ECC Roadmap Authority Index
 
-## Proposed canonical roadmap
+## Canonical roadmap
 
-- `ECC_SUPERIORITY_IMPLEMENTATION_MASTER_PLAN_V1.md` - corrected full build program for turning ECC into the Altus daily operating command center and surpassing conventional property-management platforms.
+- `ECC_SUPERIORITY_IMPLEMENTATION_MASTER_PLAN_V1.md` - merged canonical full build program for turning ECC into the Altus daily operating command center and surpassing conventional property-management platforms.
 
 ## Superseded historical roadmap
 


### PR DESCRIPTION
## What changed
- marks the merged ECC master plan as canonical planning authority
- aligns the roadmap authority index
- records safe removal of the two obsolete ECC shared project-source uploads

## Why
ECC continuity now belongs in its canonical repository. The uploaded Genesis/recovery files contain obsolete architecture and generic governance that should not be injected into unrelated chats.

## Validation
Documentation-only reconciliation against `main` at `5e5bd182f24c997dd743ccc5bca872ae2a64f4ff`. No runtime, database, deployment, secret, or application-code change.